### PR TITLE
BA-590: add ArticleProductUrl and ArticleImageUrl Parameters to KlarnaKP

### DIFF
--- a/src/PaymentMethods/KlarnaKP/Models/Article.ts
+++ b/src/PaymentMethods/KlarnaKP/Models/Article.ts
@@ -1,4 +1,9 @@
-import { Article as ArticleClass } from '../../../Models';
+import { Article as ArticleClass, IArticle } from '../../../Models';
+
+export interface IKlarnaKpArticle extends IArticle {
+    imageUrl?: string;
+    productUrl?: string;
+}
 
 export default class Article extends ArticleClass {
     get description(): string {
@@ -23,6 +28,14 @@ export default class Article extends ArticleClass {
 
     set identifier(identifier: string) {
         this.set('number', identifier);
+    }
+
+    set imageUrl(imageUrl: string) {
+        this.set('imageUrl', imageUrl);
+    }
+
+    set productUrl(productUrl: string) {
+        this.set('productUrl', productUrl);
     }
 
     set(name: string, value: any, hidden: boolean = false): this {

--- a/src/PaymentMethods/KlarnaKP/Models/IReserve.ts
+++ b/src/PaymentMethods/KlarnaKP/Models/IReserve.ts
@@ -1,13 +1,13 @@
 import { Gender } from '../../../Constants';
-import { IArticle, ICustomer, IRequest, ServiceParameter } from '../../../Models';
+import { ICustomer, IRequest, ServiceParameter } from '../../../Models';
 import { Customer } from './Customer';
-import Article from './Article';
+import Article, { IKlarnaKpArticle } from './Article';
 
 export interface IReserve extends IRequest {
     gender?: Gender.MALE | Gender.FEMALE;
     billing?: ICustomer;
     shipping?: ICustomer;
-    articles?: Partial<IArticle>[];
+    articles?: Partial<IKlarnaKpArticle>[];
     operatingCountry?: string;
     reservationNumber?: string;
     shippingSameAsBilling?: boolean;
@@ -39,7 +39,7 @@ export class Reserve extends ServiceParameter implements IReserve {
         this.set('shipping', new Customer({ prefix: 'shipping', ...value }));
     }
 
-    set articles(value: IArticle[]) {
+    set articles(value: IKlarnaKpArticle[]) {
         this.set(
             'articles',
             value.map((article) => new Article(article))

--- a/tests/PaymentMethods/KlarnaKp.test.ts
+++ b/tests/PaymentMethods/KlarnaKp.test.ts
@@ -1,5 +1,5 @@
 import buckarooClientTest from '../BuckarooClient.test';
-import { Gender } from '../../src';
+import { Gender, uniqid } from '../../src';
 
 const klarnaKp = buckarooClientTest.method('klarnakp');
 
@@ -18,6 +18,7 @@ describe('KlarnaKp', () => {
     test('Reserve', async () => {
         return klarnaKp
             .reserve({
+                invoice: uniqid(),
                 gender: Gender.MALE,
                 operatingCountry: 'NL',
                 pno: '01011990',
@@ -44,6 +45,8 @@ describe('KlarnaKp', () => {
                         vatPercentage: 21,
                         quantity: 2,
                         price: 20.1,
+                        imageUrl: 'https://example.com/image',
+                        productUrl: 'https://example.com/product',
                     },
                     {
                         identifier: 'Articlenumber2',
@@ -51,6 +54,8 @@ describe('KlarnaKp', () => {
                         vatPercentage: 21,
                         quantity: 1,
                         price: 10.1,
+                        imageUrl: 'https://example.com/image',
+                        productUrl: 'https://example.com/product',
                     },
                 ],
             })


### PR DESCRIPTION
Add optional ArticleProductUrl and ArticleImageUrl parameters to the Klarna SDK to include product images and URLs.

