### PR TITLE
BTI-1076: Add In3 Authorize/Capture flow for ABN-AMRO

### DIFF
--- a/example/transaction/in3-abn-amro-achteraf-betalen.js
+++ b/example/transaction/in3-abn-amro-achteraf-betalen.js
@@ -3,92 +3,101 @@ import { getIPAddress, RecipientCategory, uniqid } from '../../src';
 
 const in3 = buckarooClient.method('In3');
 
-//Pay
-in3
-    .pay({
-        amountDebit: 100,
-        description: 'in3 pay',
-        order: uniqid(),
-        invoice: uniqid(),
-        clientIP: getIPAddress(),
-        route: 'abn_b2b',
-        billing: {
-            recipient: {
-                category: RecipientCategory.PERSON,
-                initials: 'TA',
-                firstName: 'Test',
-                lastName: 'Acceptatie',
-                birthDate: '1990-01-01',
-                customerNumber: 'XXXXX',
-                companyName: 'Buckaroo B.V.',
-                chamberOfCommerce: 'XXXXXX41',
-            },
-            address: {
-                street: 'Hoofdstraat',
-                houseNumber: '80',
-                houseNumberAdditional: 'a',
-                zipcode: '8441ER',
-                city: 'Heerenveen',
-                country: 'NL',
-            },
-            phone: {
-                mobile: '0612345678',
-            },
-            email: 'test@buckaroo.nl',
+// ABN-AMRO "Zakelijk op rekening" runs over the abn_b2b route.
+const order = {
+    amountDebit: 100,
+    description: 'in3 abn-amro',
+    order: uniqid(),
+    invoice: uniqid(),
+    clientIP: getIPAddress(),
+    route: 'abn_b2b',
+    billing: {
+        recipient: {
+            category: RecipientCategory.PERSON,
+            initials: 'TA',
+            firstName: 'Test',
+            lastName: 'Acceptatie',
+            birthDate: '1990-01-01',
+            customerNumber: 'XXXXX',
+            companyName: 'Buckaroo B.V.',
+            chamberOfCommerce: 'XXXXXX41',
         },
-        shipping: {
-            recipient: {
-                category: RecipientCategory.PERSON,
-                careOf: 'J',
-                firstName: 'Test',
-                lastName: 'Acceptatie',
-                chamberOfCommerce: 'XXXXXX41',
-            },
-            address: {
-                street: 'Hoofdstraat',
-                houseNumber: '80',
-                houseNumberAdditional: 'a',
-                zipcode: '8441ER',
-                city: 'Heerenveen',
-                country: 'NL',
-            },
+        address: {
+            street: 'Hoofdstraat',
+            houseNumber: '80',
+            houseNumberAdditional: 'a',
+            zipcode: '8441ER',
+            city: 'Heerenveen',
+            country: 'NL',
         },
-        articles: [
-            {
-                identifier: 'Articlenumber1',
-                type: 'Physical',
-                description: 'Blue Toy Car',
-                category: 'test product',
-                vatPercentage: 21,
-                quantity: 2,
-                price: 25,
-            },
-            {
-                identifier: 'Articlenumber2',
-                type: 'Physical',
-                description: 'Red Toy Car',
-                category: 'test product',
-                vatPercentage: 21,
-                quantity: 1,
-                price: 25,
-            },
-            {
-                identifier: 'USPShippingID',
-                type: 'Physical',
-                description: 'UPS',
-                category: 'test product',
-                vatPercentage: 21,
-                quantity: 1,
-                price: 25,
-            },
-        ],
-    })
-    .request();
-//Refund
-in3
-    .refund({
-        originalTransactionKey: 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        amountCredit: 10.1,
-        invoice: 'In3 Refund',
-    })
-    .request();
+        phone: {
+            mobile: '0612345678',
+        },
+        email: 'test@buckaroo.nl',
+    },
+    shipping: {
+        recipient: {
+            category: RecipientCategory.PERSON,
+            careOf: 'J',
+            firstName: 'Test',
+            lastName: 'Acceptatie',
+            chamberOfCommerce: 'XXXXXX41',
+        },
+        address: {
+            street: 'Hoofdstraat',
+            houseNumber: '80',
+            houseNumberAdditional: 'a',
+            zipcode: '8441ER',
+            city: 'Heerenveen',
+            country: 'NL',
+        },
+    },
+    articles: [
+        {
+            identifier: 'Articlenumber1',
+            type: 'Physical',
+            description: 'Blue Toy Car',
+            category: 'test product',
+            vatPercentage: 21,
+            quantity: 2,
+            price: 25,
+        },
+        {
+            identifier: 'Articlenumber2',
+            type: 'Physical',
+            description: 'Red Toy Car',
+            category: 'test product',
+            vatPercentage: 21,
+            quantity: 1,
+            price: 25,
+        },
+        {
+            identifier: 'USPShippingID',
+            type: 'Physical',
+            description: 'UPS',
+            category: 'test product',
+            vatPercentage: 21,
+            quantity: 1,
+            price: 25,
+        },
+    ],
+};
+
+// Pay (standard In3 PAY flow)
+in3.pay(order).request();
+
+// Authorize (ABN-AMRO "Zakelijk op rekening" only allows Authorize/Capture, not Pay)
+in3.authorize(order).request();
+
+// Capture the previously authorized transaction
+in3.capture({
+    ...order,
+    originalTransactionKey: 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+}).request();
+
+// Refund
+in3.refund({
+    originalTransactionKey: 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+    amountCredit: 10.1,
+    invoice: 'In3 Refund',
+}).request();

--- a/example/transaction/in3-abn-amro-achteraf-betalen.ts
+++ b/example/transaction/in3-abn-amro-achteraf-betalen.ts
@@ -3,10 +3,10 @@ import { getIPAddress, RecipientCategory, uniqid } from '../../src';
 
 const in3 = buckarooClient.method('In3');
 
-//Pay
-in3.pay({
+// ABN-AMRO "Zakelijk op rekening" runs over the abn_b2b route.
+const order = {
     amountDebit: 100,
-    description: 'in3 pay',
+    description: 'in3 abn-amro',
     order: uniqid(),
     invoice: uniqid(),
     clientIP: getIPAddress(),
@@ -81,8 +81,21 @@ in3.pay({
             price: 25,
         },
     ],
+};
+
+// Pay (standard In3 PAY flow)
+in3.pay(order).request();
+
+// Authorize (ABN-AMRO "Zakelijk op rekening" only allows Authorize/Capture, not Pay)
+in3.authorize(order).request();
+
+// Capture the previously authorized transaction
+in3.capture({
+    ...order,
+    originalTransactionKey: 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
 }).request();
-//Refund
+
+// Refund
 in3.refund({
     originalTransactionKey: 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
     amountCredit: 10.1,

--- a/src/PaymentMethods/In3/index.ts
+++ b/src/PaymentMethods/In3/index.ts
@@ -1,6 +1,6 @@
 import { PayablePaymentMethod } from '../../Services';
 import { IPaymentRequest, IRefundRequest } from '../../Models';
-import Pay from './Models/Pay';
+import Pay, { IPay } from './Models/Pay';
 import { ServiceCode } from '../../Utils';
 
 export default class In3 extends PayablePaymentMethod {
@@ -10,6 +10,18 @@ export default class In3 extends PayablePaymentMethod {
 
     pay(payload: IPaymentRequest) {
         return super.pay(payload, new Pay(payload));
+    }
+
+    authorize(payload: IPay) {
+        this.setPayPayload(payload);
+        this.setServiceList('Authorize', new Pay(payload));
+        return this.transactionRequest();
+    }
+
+    capture(payload: IPay) {
+        this.setPayPayload(payload);
+        this.setServiceList('Capture', new Pay(payload));
+        return this.transactionRequest();
     }
 
     refund(payload: IRefundRequest) {

--- a/tests/PaymentMethods/In3.test.ts
+++ b/tests/PaymentMethods/In3.test.ts
@@ -32,6 +32,16 @@ describe('Testing In3 methods', () => {
         const response = await method.pay({...payload, route: 'abn_b2b'}).request();
         expect(response.isPendingProcessing()).toBeTruthy();
     });
+    test('Authorize with ABN-AMRO', async () => {
+        const response = await method.authorize({ ...payload, route: 'abn_b2b' }).request();
+        expect(response.isPendingProcessing()).toBeTruthy();
+    });
+    test('Capture with ABN-AMRO', async () => {
+        const response = await method
+            .capture({ ...payload, route: 'abn_b2b', originalTransactionKey: '4BC466160ACB460EAFB8923D1BBFE33A' })
+            .request();
+        expect(response.isSuccess()).toBeTruthy();
+    });
     test('Refund', async () => {
         const response = await method
             .refund(


### PR DESCRIPTION
- Add `authorize()` and `capture()` to the In3 payment method for ABN-AMRO "Zakelijk op rekening", which requires an Authorize/Capture flow (route `abn_b2b`) instead of the standard Pay flow.
- Both build the full In3 `Pay` model, mirroring the merged PHP SDK and the existing Afterpay/CreditCard pattern.
- Existing In3 Pay and Refund flows are unchanged — backward compatible.
- Add integration tests for In3 Authorize and Capture, and document the flow in the ABN-AMRO example (ts + js).
- Note: the live Authorize/Capture tests currently fail because the shared test merchant isn't provisioned for In3 Authorize (Pay accepts the same route). Code matches the PHP reference; needs an Authorize-enabled key to go green.