### PR TITLE
BTI-1317: Add GitHub Action to publish node-sdk to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,86 @@
+name: Publish npm package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-npm
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+
+    # If the npmjs.com trusted publisher policy names an environment, it must
+    # be this exact name — otherwise leave that field blank on npmjs.com.
+    environment: release
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      # Trusted publishing needs Node >= 22.14. No cache: the repo commits no lockfile.
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      # setup-node writes `_authToken=${NODE_AUTH_TOKEN}` into .npmrc. With no token
+      # that expands to empty, which npm reads as "auth configured" and skips OIDC.
+      - name: Remove empty auth token from .npmrc
+        run: sed -i '/_authToken/d' "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+
+      # Trusted publishing needs npm >= 11.5.1.
+      - name: Ensure npm supports trusted publishing
+        run: npm install --global npm@11
+
+      # The release event cannot filter on tag pattern, so enforce v* here. The tag
+      # is attacker-controllable — pass it through env, never inline into the shell.
+      - name: Derive package version from the release tag
+        id: version
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          version="${TAG_NAME#v}"
+          if [ "$version" = "$TAG_NAME" ]; then
+            echo "::error::Refusing to publish: tag '$TAG_NAME' does not start with 'v'"
+            exit 1
+          fi
+          if ! [[ "$version" =~ ^[0-9]+(\.[0-9]+)*(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Refusing to publish: tag '$TAG_NAME' is not a valid version"
+            exit 1
+          fi
+          echo "value=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Check package.json matches the release tag
+        env:
+          EXPECTED: ${{ steps.version.outputs.value }}
+        run: |
+          actual="$(node --print 'require("./package.json").version')"
+          if [ "$actual" != "$EXPECTED" ]; then
+            echo "::error::package.json is $actual but the release tag says $EXPECTED"
+            exit 1
+          fi
+
+      # No lockfile is committed, so `npm ci` is not an option.
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      # Rebuilds dist/ on the runner, so a stale local dist/ can never be published.
+      - name: Build
+        run: npm run build
+
+      # No token: npm exchanges the job's OIDC token via the trusted publisher policy.
+      - name: Publish to npm
+        run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "dotenv": "^16.0.3",
         "jest": "^29.4.2",
         "prettier": "^2.8.3",
+        "rollup": "^4.62.4",
         "ts-jest": "^29.0.5",
         "tslib": "^2.8.1",
         "typescript": "^4.9.4"


### PR DESCRIPTION
Jira: BTI-1317

### What

- Add `.github/workflows/publish.yml` — publishing to npm is no longer done by hand
- Trigger: a published GitHub release
- Rebuilds `dist/` from source on the runner, so a stale local `dist/` can never be shipped
- Auth: npm trusted publishing (OIDC). No `NPM_TOKEN` secret stored in the repo
- Provenance attestations are generated automatically
- Refuses to publish if the tag is not `v<version>`, or if it does not match `package.json`
- Release tag is read through `env:`, never inlined into the shell
- `id-token: write` only on the job that needs it, everything else read-only

### Also

- Declare `rollup` in `devDependencies`. The `@rollup/plugin-*` packages list it only as an *optional* peer dependency, so a clean `npm install` never installed it and the build failed with `rollup: command not found`. Verified on a fresh install — the resulting bundle is byte-identical to the previous one.

### Deliberate choices

- **No tests in the publish job.** The suite calls the live Buckaroo TEST gateway and needs `BPE_*` credentials, so gateway flakiness would block releases. A PR-time test workflow is separate work.
- **OIDC instead of `NPM_TOKEN`**, which the ticket originally suggested. No long-lived token to rotate or leak.
- **`npm install`, not `npm ci`.** No lockfile is committed. `setup-node`'s cache is off for the same reason.
- **`sed` on `.npmrc`.** `setup-node` writes `_authToken=${NODE_AUTH_TOKEN}`; with no token that expands to empty, npm reads it as "auth configured" and skips OIDC entirely.

### Before the first release

- [ ] npmjs.com → `@buckaroo/buckaroo_sdk` → Settings → Trusted publisher: GitHub Actions, repo `buckaroo-it/BuckarooSDK_Node`, workflow `publish.yml`, environment `release` (or blank). The workflow cannot verify this — without it the first release fails.
- [ ] The workflow runs from the tag's commit, so it must reach `master` before the next release tag is cut.
- [ ] Release tag must equal `package.json` exactly (currently `1.12.1` → tag `v1.12.1`).

### Verification

- `actionlint` — clean
- Shell snippets — `bash -n` passes
- Tag logic — accepts `v1.12.0`, `v1.12.0-beta.1`; rejects `1.12.0`, `vabc`, `v1.0; rm -rf /`
- Fresh `npm install` + build in a clean temp dir — fails before the rollup fix, passes after, output byte-identical